### PR TITLE
fix(cro): whitelist tools for claude-code-action

### DIFF
--- a/.github/workflows/cro-agent.yml
+++ b/.github/workflows/cro-agent.yml
@@ -58,3 +58,4 @@ jobs:
             3. Create a new branch `cro-agent/report-${{ github.run_id }}`, commit only the new report file with message `chore(cro): monthly report`, push to origin, and open a PR to `main` titled `chore(cro): monthly report` with a 1-2 sentence body summarizing the top recommendation.
           claude_args: |
             --max-turns 30
+            --allowedTools "Read,Write,Edit,Bash"


### PR DESCRIPTION
## Summary

The first scheduled run hit `error_max_turns` with 24 permission denials — Claude Code was getting blocked from running `git`, `gh`, and file tools because no `--allowedTools` was set in `claude_args`. Adds an explicit allow-list so the agent can actually do the work.

## Test plan

- [ ] Run workflow_dispatch from this branch and confirm it produces a `cro/report-<date>.md` and opens a PR