### PR TITLE
Open external links in new tabs and trim unused login button

### DIFF
--- a/components/footer.jsx
+++ b/components/footer.jsx
@@ -5,7 +5,7 @@ import { kronosapiensUrl, supportUrl } from '../utils/constants';
 export default function () {
   return (
     <div className="text-center p-3 bg-light">
-      &copy; { new Date().getFullYear() } <Link href={kronosapiensUrl}>Kronosapiens Labs</Link>
+      &copy; { new Date().getFullYear() } <Link href={kronosapiensUrl} target="_blank">Kronosapiens Labs</Link>
       <br></br>
       <Link href="/privacy.html" style={{ fontSize: "14px" }}>Privacy Policy</Link>
       &nbsp;·&nbsp;

--- a/components/navbar.jsx
+++ b/components/navbar.jsx
@@ -28,20 +28,7 @@ export default function () {
             <Nav.Link href={blogUrl} target="_blank">📚 Blog ↗</Nav.Link>
           </Nav>
         </Navbar.Collapse>
-        {/* <LoginButton /> */}
       </Container>
     </Navbar>
-  )
-}
-
-export function LoginButton() {
-  const loginUrl = "https://zaratan.managebuilding.com/Resident/portal";
-
-  return (
-    <ul className="navbar-nav navbar-right">
-      <li className="nav-item btn btn-sm btn-outline-success">
-        <a className="nav-link" href={loginUrl}><b>Housemate Login</b></a>
-      </li>
-  </ul>
   )
 }

--- a/pages/about.jsx
+++ b/pages/about.jsx
@@ -71,7 +71,7 @@ export default function () {
 
               <p>
                 We see these challenges as linked, and believe that <b>coliving can address them all</b>, by enabling residents to co-create their own housing —
-                building relationships, saving money, and <Link href="https://geo.coop/archives/huetman604.htm">cultivating skills</Link> in the process.
+                building relationships, saving money, and <Link href="https://geo.coop/archives/huetman604.htm" target="_blank">cultivating skills</Link> in the process.
               </p>
 
               <p>
@@ -87,7 +87,7 @@ export default function () {
               <p>
                 To-date we have built two sites, <Link href="/houses/sage">Sage House</Link> and <Link href="/houses/cactus">Cactus Cottage</Link>, on a shared lot in Los Angeles.
                 We have developed a suite of pioneering organizational tools, called <Link href="/chorewheel">Chore Wheel</Link>.
-                Lastly, we have been cultivating knowledge within our community of <Link href={structuresUrl}>academics</Link> and <Link href={blogUrl}>practitioners</Link>.
+                Lastly, we have been cultivating knowledge within our community of <Link href={structuresUrl} target="_blank">academics</Link> and <Link href={blogUrl} target="_blank">practitioners</Link>.
                 Zaratan has an expansive vision, and we are in it for the long haul.
               </p>
 
@@ -95,12 +95,12 @@ export default function () {
                 <i>What is a Zaratan?</i>
               </p>
               <p>
-                A <Link href={zaratanUrl}>Zaratan</Link> is a <b>mythical giant sea turtle</b>, often mistaken for an island by sailors lost at sea.
+                A <Link href={zaratanUrl} target="_blank">Zaratan</Link> is a <b>mythical giant sea turtle</b>, often mistaken for an island by sailors lost at sea.
                 By naming ourselves after this creature, we evoke the way that organizational innovations can act as foundations for thriving communities.
                 In addition, Zaratani are known for their slow movements and long life, which we evoke through our patient and intentional approach to growth.
               </p>
               {/* <p>
-                The Zaratan is opposed by the fearsome <Link href={manticoreUrl}>Manticore</Link>, symbolizing the egotistical drive for status and control.
+                The Zaratan is opposed by the fearsome <Link href={manticoreUrl} target="_blank">Manticore</Link>, symbolizing the egotistical drive for status and control.
                 With its thick shell and careful movements, the Zaratan is able to withstand the Manticore, who quickly tires and loses its edge.
                 This (fictional) conflict evokes the way that thoughtful process can outlast charismatic leadership.
               </p> */}
@@ -165,7 +165,7 @@ export default function () {
               </p>
               <p>
                 An energetic student, Daniel studied at UC Berkeley, pursuing a double-major in Political Economy and Cognitive Science.
-                While at Cal, Daniel had his first experience of communal living through the <Link href="https://bsc.coop">Berkeley Student Cooperative</Link>.
+                While at Cal, Daniel had his first experience of communal living through the <Link href="https://bsc.coop" target="_blank">Berkeley Student Cooperative</Link>.
                 Connecting deeply with the co-op's mission, Daniel got involved in leadership, eventually becoming president — complementing his intellectual development with a rich experience of practice.
               </p>
               <p>
@@ -173,8 +173,8 @@ export default function () {
                 These experiences broadened his perspective, exposing him to a diversity of organizational structures and practices.
               </p>
               <p>
-                Returning to the United States, Daniel went to New York City and into technology, earning a master's degree in Quantitative Social Science at Columbia University, <Link href={thesisUrl}>researching voting systems</Link>.
-                Starting his career as a machine learning engineer, he soon pivoted to mechanism design, as a research engineer at the pioneering future-of-work project <Link href="https://colony.io">Colony</Link>.
+                Returning to the United States, Daniel went to New York City and into technology, earning a master's degree in Quantitative Social Science at Columbia University, <Link href={thesisUrl} target="_blank">researching voting systems</Link>.
+                Starting his career as a machine learning engineer, he soon pivoted to mechanism design, as a research engineer at the pioneering future-of-work project <Link href="https://colony.io" target="_blank">Colony</Link>.
                 In this role, Daniel gained a deeper understanding of the skills needed to design and implement complex systems.
               </p>
               <p>

--- a/pages/chorewheel/index.jsx
+++ b/pages/chorewheel/index.jsx
@@ -78,7 +78,7 @@ export default function ({ images }) {
         <Col />
         <Col md={8} xl={6}>
           <h5>
-            <b>Chore Wheel</b> is Zaratan's suite of <Link href={structuresUrl}>collaboration tools</Link>, turning <b>unspoken expectations</b> into <b>shared agreements</b>.
+            <b>Chore Wheel</b> is Zaratan's suite of <Link href={structuresUrl} target="_blank">collaboration tools</Link>, turning <b>unspoken expectations</b> into <b>shared agreements</b>.
           </h5>
 
           <hr></hr>
@@ -105,11 +105,11 @@ export default function ({ images }) {
             <Link href="/chorewheel/start" className="btn btn-primary btn-md mt-3 mb-4" onClick={() => trackEvent(CTA.cwGetStarted)}>✨ Get Started Today ✨</Link>
             <br></br>
 
-            <Link href={structuresUrl}>Read the paper</Link>
+            <Link href={structuresUrl} target="_blank">Read the paper</Link>
             &nbsp;·&nbsp;
-            <Link href={metagovUrl}>Watch the talk</Link>
+            <Link href={metagovUrl} target="_blank">Watch the talk</Link>
             &nbsp;·&nbsp;
-            <Link href={repoUrl}>See the code</Link>
+            <Link href={repoUrl} target="_blank">See the code</Link>
           </div>
 
           <hr></hr>
@@ -176,9 +176,9 @@ export function Pricing() {
           <tr><td>Up to 5 users</td><td>Up to 10 users</td><td>Up to 20 users</td></tr>
           <tr><td><s>$20/mo</s></td><td><s>$40/mo</s></td><td><s>$60/mo</s></td></tr>
           <tr>
-            <td><Button variant="outline-success" size="sm" href={roommateUrl}>Subscribe</Button></td>
-            <td><Button variant="outline-success" size="sm" href={familyUrl}>Subscribe</Button></td>
-            <td><Button variant="outline-success" size="sm" href={communityUrl}>Subscribe</Button></td>
+            <td><Button variant="outline-success" size="sm" href={roommateUrl} target="_blank">Subscribe</Button></td>
+            <td><Button variant="outline-success" size="sm" href={familyUrl} target="_blank">Subscribe</Button></td>
+            <td><Button variant="outline-success" size="sm" href={communityUrl} target="_blank">Subscribe</Button></td>
           </tr>
           <tr>
             <td><SlackButton text="Get Chores" installUrl={choresInstallUrl} /></td>

--- a/pages/chorewheel/start.jsx
+++ b/pages/chorewheel/start.jsx
@@ -126,7 +126,7 @@ export default function () {
 
           <p>
             You can install the apps by <b>clicking the buttons below</b> (must be a workspace admin).
-            You can read the <Link href={quickstartUrl}><b>getting started guide</b></Link> for more details about the apps and how to use them.
+            You can read the <Link href={quickstartUrl} target="_blank"><b>getting started guide</b></Link> for more details about the apps and how to use them.
           </p>
 
           <div className="center py-2">
@@ -149,14 +149,14 @@ export default function () {
           </p>
           <p>
             Once you do, you'll be amazed at how well everything works.
-            If you need any help, the <Link href={docsUrl}><b>project docs</b></Link> have details of how the apps work and examples for how to use them.
-            Or, just send us <Link href={supportUrl} target="_blank" onClick={() => trackEvent(CTA.emailCw)}><b>an email</b></Link>.
+            If you need any help, the <Link href={docsUrl} target="_blank"><b>project docs</b></Link> have details of how the apps work and examples for how to use them.
+            Or, just send us <Link href={supportUrl} onClick={() => trackEvent(CTA.emailCw)}><b>an email</b></Link>.
           </p>
 
           <p>
             We'd love to hear about your experience!
             Share your stories (tag <Link href={instagramUrl} target="_blank">@zaratan.world</Link>),
-            or <Link href={contactUrl} target="_blank" onClick={() => trackEvent(CTA.emailCw)}>contact us</Link>.
+            or <Link href={contactUrl} onClick={() => trackEvent(CTA.emailCw)}>contact us</Link>.
           </p>
 
           <br></br>
@@ -213,8 +213,8 @@ export default function () {
           <p>
             <b>Is Chore Wheel open-source?</b>
             <br></br>
-            Yes! Chore Wheel is open-source under the <Link href="https://choosealicense.com/licenses/agpl-3.0/">AGPL-3 license</Link>.
-            You can see the <Link href={repoUrl}>source code on GitHub</Link>,
+            Yes! Chore Wheel is open-source under the <Link href="https://choosealicense.com/licenses/agpl-3.0/" target="_blank">AGPL-3 license</Link>.
+            You can see the <Link href={repoUrl} target="_blank">source code on GitHub</Link>,
             and contributions are welcome.
           </p>
 
@@ -230,9 +230,9 @@ export default function () {
           <p>
             <b>What were the influences for Chore Wheel?</b>
             <br></br>
-            Chore Wheel was heavily influenced by the work of Nobel Laureate Elinor Ostrom (<Link href={bookUrlOstrom}>Governing the Commons</Link>),
-            Stafford Beer (<Link href={bookUrlBeer}>Designing Freedom</Link>),
-            and Frederic Laloux (<Link href={bookUrlLaloux}>Reinventing Organizations</Link>).
+            Chore Wheel was heavily influenced by the work of Nobel Laureate Elinor Ostrom (<Link href={bookUrlOstrom} target="_blank">Governing the Commons</Link>),
+            Stafford Beer (<Link href={bookUrlBeer} target="_blank">Designing Freedom</Link>),
+            and Frederic Laloux (<Link href={bookUrlLaloux} target="_blank">Reinventing Organizations</Link>).
             While Chore Wheel might seem like a "tech" solution to a human problem,
             it's actually the result of a lot of deep thinking about how people work together.
           </p>
@@ -247,9 +247,9 @@ export default function () {
           </p>
 
           <ul>
-            <li>For <b>app details</b>, see the <Link href={docsUrl}>full documentation</Link></li>
-            <li>For <b>peer support</b>, join our <Link href={slackCommunityUrl}>Slack community</Link></li>
-            <li>For <b>source code</b>, see the <Link href={repoUrl}>GitHub repository</Link></li>
+            <li>For <b>app details</b>, see the <Link href={docsUrl} target="_blank">full documentation</Link></li>
+            <li>For <b>peer support</b>, join our <Link href={slackCommunityUrl} target="_blank">Slack community</Link></li>
+            <li>For <b>source code</b>, see the <Link href={repoUrl} target="_blank">GitHub repository</Link></li>
             <li>For <b>general questions</b>, please <Link href={contactUrl} onClick={() => trackEvent(CTA.emailCw)}>contact us</Link></li>
           </ul>
         </Col>

--- a/pages/houses/cactus.jsx
+++ b/pages/houses/cactus.jsx
@@ -66,7 +66,7 @@ export default function ({ images }) {
 
           {/* TODO: Add vacancy email signup */}
 
-          <p><i>Cactus Cottage is a proud supporter of the <Link href={tongvaUrl}>Tongva Conservancy</Link></i></p>
+          <p><i>Cactus Cottage is a proud supporter of the <Link href={tongvaUrl} target="_blank">Tongva Conservancy</Link></i></p>
         </Col>
         <Col />
       </Row>

--- a/pages/houses/sage.jsx
+++ b/pages/houses/sage.jsx
@@ -58,7 +58,7 @@ export default function ({ images }) {
         <Col md={8} xl={6}>
           <div className="center">
             <p>
-              <em>As seen on <Link href={nbcUrl}>NBC4</Link> and <Link href={supernuclearUrl}>Supernuclear</Link></em>
+              <em>As seen on <Link href={nbcUrl} target="_blank">NBC4</Link> and <Link href={supernuclearUrl} target="_blank">Supernuclear</Link></em>
             </p>
 
             <p>
@@ -81,13 +81,13 @@ export default function ({ images }) {
             </p>
 
             <p>
-              Live with people who <b>actually care</b> about sharing space — a real community that runs itself, not a sterile brand with paid staff and awkward events.
+              Live with people who <b>genuinely care</b> about sharing space — a real community that runs itself.
             </p>
 
             <Button variant="warning" size="md" className="mt-2 mb-4" href={tallyInterestUrl} target="_blank" onClick={() => trackEvent(CTA.waitlistSage)}>Join the Waitlist</Button>
 
             <p>
-              You can also <b><Link href={instagramSageUrl}>follow us</Link></b> on Instagram.
+              You can also <b><Link href={instagramSageUrl} target="_blank">follow us</Link></b> on Instagram!
             </p>
           </div>
 
@@ -115,7 +115,7 @@ export default function ({ images }) {
 
           <br></br>
 
-          <p><i>Sage House is a proud supporter of the <Link href={tongvaUrl}>Tongva Conservancy</Link></i></p>
+          <p><i>Sage House is a proud supporter of the <Link href={tongvaUrl} target="_blank">Tongva Conservancy</Link></i></p>
         </Col>
         <Col />
       </Row>

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -86,7 +86,7 @@ export default function () {
             If your house is experiencing <b>drama</b> or <b>burnout</b>, check out <Link href="/chorewheel">Chore Wheel</Link>.
           </p>
           <p>
-            If you <b>just want to chat</b>, <Link href="mailto:hello@zaratan.world">drop us a line</Link> or find us on <Link href={instagramUrl}>Instagram</Link>.
+            If you <b>just want to chat</b>, <Link href="mailto:hello@zaratan.world">drop us a line</Link> or find us on <Link href={instagramUrl} target="_blank">Instagram</Link>.
           </p>
 
           <br></br>
@@ -99,7 +99,7 @@ export default function () {
       <Row className="p-5">
         <Col />
         <Col md={8} xl={6}  style={{position:"relative", height:"600px"}}>
-          <Link href={instagramUrl}>
+          <Link href={instagramUrl} target="_blank">
             <Image
               fill
               src={zaratanPic}

--- a/utils/constants.js
+++ b/utils/constants.js
@@ -6,7 +6,6 @@ export const tallyInterestUrl = "https://tally.so/r/gDLPzN";
 export const instagramUrl = "https://www.instagram.com/zaratan.world";
 export const instagramSageUrl = "https://www.instagram.com/sage.co.op";
 export const kronosapiensUrl ="https://kronosapiens.github.io"
-export const loginUrl = "https://zaratan.managebuilding.com/Resident/portal";
 export const contactUrl = "mailto:hello@zaratan.world";
 export const supportUrl = "mailto:support@zaratan.world";
 export const calendlyUrl = "https://calendly.com/zaratan-krono/30min";


### PR DESCRIPTION
Audits every link on the public site so that external (http/https) links open in a new tab via `target="_blank"`, while internal route links and `mailto:` links keep default behavior.

Removes the unused `LoginButton` component and its now-orphaned `loginUrl` constant — the only call site had been commented out.

Also softens the Sage House pitch by dropping the "not a sterile brand with paid staff and awkward events" swipe; the positive framing carries the line on its own.