### PR TITLE
refactor(sage): restyle FAQ and restructure page layout

### DIFF
--- a/pages/houses/sage.jsx
+++ b/pages/houses/sage.jsx
@@ -62,18 +62,17 @@ export default function ({ images }) {
             </p>
 
             <p>
-              A beautifully-restored 1905 Craftsman in the heart of vibrant <b>Highland Park, Los Angeles</b> — with cafes, bars, and restaurants along Figueroa Street and York Boulevard, and quick access to Eagle Rock, South Pasadena, and Downtown LA via the Metro Gold Line.
+              A beautifully-restored 1905 Craftsman in the heart of vibrant <b>Highland Park, Los Angeles</b> — steps away from the cafes, bars, and restaurants of Figueroa Street and York Boulevard, with quick access to Eagle Rock, South Pasadena, and Downtown LA via the Metro Gold Line.
             </p>
 
             <p>
               This nine-bedroom house features
               hardwood floors,
               restaurant-style kitchen,
-              elegant dining room,
-              sunny living room,
+              original living and dining rooms,
               art space,
-              upstairs deck,
-              backyard fire pit,
+              deck,
+              fire pit,
               recording studio,
               gym,
               guest room,
@@ -81,14 +80,15 @@ export default function ({ images }) {
             </p>
 
             <p>
-              Live with people who <b>genuinely care</b> about sharing space — a real community that runs itself.
+              Sage is  <Link href={instagramSageUrl} target="_blank">a vibrant and dynamic community</Link>, with residents who support and care for each other.
+              With nine people sharing space, Sage offers a feeling of abundance along with highly competitive rents.
             </p>
 
             <Button variant="warning" size="md" className="mt-2 mb-4" href={tallyInterestUrl} target="_blank" onClick={() => trackEvent(CTA.waitlistSage)}>Join the Waitlist</Button>
 
-            <p>
-              You can also <b><Link href={instagramSageUrl} target="_blank">follow us</Link></b> on Instagram!
-            </p>
+            <br></br>
+
+            <p><i>Sage House is a proud supporter of the <Link href={tongvaUrl} target="_blank">Tongva Conservancy</Link></i></p>
           </div>
 
           <hr></hr>
@@ -115,50 +115,7 @@ export default function ({ images }) {
 
           <br></br>
 
-          <h5>Frequently Asked Questions</h5>
-
-          <h6>Is Sage House coliving?</h6>
-          <p>
-            Yes. Sage House is a 9-bedroom coliving home in Highland Park, Los Angeles.
-            Residents have private bedrooms and share fully-equipped common areas — a restaurant-style kitchen, dining room, living room, art space, gym, recording studio, and backyard with fire pit.
-            Leases are initially 4 months, and then month-to-month for as long as you want to stay.
-          </p>
-
-          <h6>How much does coliving at Sage House cost?</h6>
-          <p>
-            Rent starts at $1,140/month and varies by room.
-            Pricing is all-inclusive — utilities, internet, household supplies, and food staples are covered.
-            There are no hidden fees.
-          </p>
-
-          <h6>Where is Sage House located?</h6>
-          <p>
-            Sage House is in <b>Highland Park, Los Angeles</b>, close to Eagle Rock, South Pasadena, and Downtown LA.
-            The neighborhood is walkable, served by the Metro Gold Line, steps from Figueroa Street's restaurants, cafes, and bookstores, and a short walk to York Boulevard.
-          </p>
-
-          <h6>What's included in rent?</h6>
-          <p>
-            All utilities, internet, household supplies, and food staples — plus access to common space including kitchen, dining room, art space, gym, recording studio, fire pit, and guest room.
-          </p>
-
-          <h6>Who lives at Sage House?</h6>
-          <p>
-            Residents are professionals, creatives, and students who want real community at home.
-            The residents run the house with the help of <Link href="/chorewheel">open-source tools.</Link>
-          </p>
-
-          <h6>How do I apply?</h6>
-          <p>
-            Join the waitlist below — we'll reach out when a room opens up that matches what you're looking for.
-          </p>
-
-          <Button variant="warning" size="md" className="mt-3 mb-2" href={tallyInterestUrl} target="_blank" onClick={() => trackEvent(CTA.waitlistSage)}>Join the Waitlist</Button>
-
-          <br></br>
-          <br></br>
-
-          <p><i>Sage House is a proud supporter of the <Link href={tongvaUrl} target="_blank">Tongva Conservancy</Link></i></p>
+          <Carousel images={images} height={500} alt="Sage House photo" />
         </Col>
         <Col />
       </Row>
@@ -166,7 +123,55 @@ export default function ({ images }) {
       <Row className="p-5">
         <Col />
         <Col md={8} xl={6}>
-          <Carousel images={images} height={500} alt="Sage House photo" />
+          <h5>Frequently Asked Questions</h5>
+          <hr></hr>
+
+          <p>
+            <b>Is Sage House coliving?</b>
+            <br></br>
+            Yes. Sage is a 9-bedroom coliving house in Highland Park, Los Angeles.
+            Residents have private bedrooms and share fully-equipped common areas — a restaurant-style kitchen, dining room, living room, art space, gym, recording studio, and backyard with fire pit.
+            Leases are initially 4 months, then month-to-month for as long as you want to stay.
+          </p>
+
+          <p>
+            <b>How much does coliving at Sage House cost?</b>
+            <br></br>
+            Rent starts at $1,140/month and varies by room.
+            Pricing is all-inclusive — utilities, internet, household supplies, and food staples are covered.
+            There are no extra service or community fees.
+          </p>
+
+          <p>
+            <b>What is life like at Sage House?</b>
+            <br></br>
+            Residents are professionals, creatives, and students who want meaningful relationships at home, and the abundance that comes from sharing space.
+            The residents contribute 4-5 hours of chores per month and make decisions with the help of <Link href="/chorewheel">open-source tools.</Link>
+          </p>
+
+          <p>
+            <b>Where is Sage House located?</b>
+            <br></br>
+            Sage House is in Highland Park, Los Angeles, close to Eagle Rock, South Pasadena, and Downtown LA on the Metro Gold Line.
+            The area is highly walkable, just steps from Figueroa Street and York Boulevard's restaurants, bars, and cafes.
+          </p>
+
+          <p>
+            <b>What's included in rent?</b>
+            <br></br>
+            All utilities, internet, household supplies, and food staples — plus access to common space including kitchen, dining room, art space, gym, recording studio, fire pit, and guest room.
+            Coin-op laundry and dedicated parking spots are available for an extra cost.
+          </p>
+
+          <p>
+            <b>How do I move in?</b>
+            <br></br>
+            Join the waitlist below — we'll reach out when a room opens up that meets your needs.
+          </p>
+
+          <div className="center">
+            <Button variant="warning" size="md" className="mt-3 mb-2" href={tallyInterestUrl} target="_blank" onClick={() => trackEvent(CTA.waitlistSage)}>Join the Waitlist</Button>
+          </div>
         </Col>
         <Col />
       </Row>


### PR DESCRIPTION
## Summary
- Mirror the chorewheel/start FAQ pattern: \`<h5>\` + \`<hr/>\` opener and one \`<p>\` per question with bold question, \`<br/>\`, and answer.
- Move the carousel into the red band so the page alternates white-red-white, with the FAQ in its own white row below.
- Polish pitch copy (room descriptions, neighborhood phrasing) and fold the Instagram link into the "vibrant and dynamic community" line.
- Refine FAQ questions and answers (new "What is life like at Sage House?", clearer fees/laundry/parking notes).

## Test plan
- [ ] Verify Sage page renders correctly on desktop and mobile
- [ ] Confirm carousel sits inside the red band and FAQ in white below
- [ ] Click "Join the Waitlist" and Instagram links to verify tracking + URLs