### PR TITLE
feat(seo): add JSON-LD structured data

### DIFF
--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -61,6 +61,15 @@ export  default function ({ Component, pageProps }) {
         <meta name="twitter:description" content={pageDescription} />
         <meta name="twitter:image" content={pageImage} />
         <meta name="twitter:image:alt" content={pageImageAlt} />
+
+        {/* JSON-LD structured data */}
+        {(pageProps.pageStructuredData || []).map((schema, i) => (
+          <script
+            key={i}
+            type="application/ld+json"
+            dangerouslySetInnerHTML={{ __html: JSON.stringify(schema) }}
+          />
+        ))}
       </Head>
 
       <Layout>

--- a/pages/houses/cactus.jsx
+++ b/pages/houses/cactus.jsx
@@ -17,7 +17,26 @@ export async function getStaticProps() {
 
   const regex = /public\/images\/cactus\/mls\/.*\.jpg/i;
   const images = await getImages({ regex });
-  return { props: { pageTitle, pageDescription, images } }
+
+  const pageStructuredData = [
+    {
+      "@context": "https://schema.org",
+      "@type": "LodgingBusiness",
+      "name": "Cactus Cottage",
+      "description": pageDescription,
+      "url": "https://zaratan.world/houses/cactus",
+      "address": {
+        "@type": "PostalAddress",
+        "addressLocality": "Los Angeles",
+        "addressRegion": "CA",
+        "addressCountry": "US",
+      },
+      "priceRange": "$$",
+      "numberOfRooms": 1,
+    },
+  ];
+
+  return { props: { pageTitle, pageDescription, images, pageStructuredData } }
 }
 
 export default function ({ images }) {

--- a/pages/houses/sage.jsx
+++ b/pages/houses/sage.jsx
@@ -20,7 +20,27 @@ export async function getStaticProps() {
 
   const regex = /public\/images\/sage\/mls\/.*\.jpg/i;
   const images = await getImages({ regex });
-  return { props: { pageTitle, pageDescription, pageImage, images } }
+
+  const pageStructuredData = [
+    {
+      "@context": "https://schema.org",
+      "@type": "LodgingBusiness",
+      "name": "Sage House",
+      "description": pageDescription,
+      "url": "https://zaratan.world/houses/sage",
+      "image": pageImage,
+      "address": {
+        "@type": "PostalAddress",
+        "addressLocality": "Los Angeles",
+        "addressRegion": "CA",
+        "addressCountry": "US",
+      },
+      "priceRange": "$$",
+      "numberOfRooms": 9,
+    },
+  ];
+
+  return { props: { pageTitle, pageDescription, pageImage, images, pageStructuredData } }
 }
 
 export default function ({ images }) {

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -15,7 +15,24 @@ import { joysOfColivingUrl, instagramUrl, mailchimpGeneral } from '../utils/cons
 export async function getStaticProps() {
   const pageDescription =
     "Zaratan Coliving builds naturally-affordable shared housing and open-source tools for communities in Los Angeles and beyond.";
-  return { props: { pageDescription } }
+
+  const pageStructuredData = [
+    {
+      "@context": "https://schema.org",
+      "@type": "Organization",
+      "name": "Zaratan Coliving",
+      "url": "https://zaratan.world",
+      "logo": "https://zaratan.world/images/zaratan-art.png",
+      "description": pageDescription,
+      "sameAs": [
+        "https://www.instagram.com/zaratan.world",
+        "https://blog.zaratan.world",
+        "https://github.com/zaratanDotWorld/choreWheel",
+      ],
+    },
+  ];
+
+  return { props: { pageDescription, pageStructuredData } }
 }
 
 export default function () {


### PR DESCRIPTION
## Summary
- Render JSON-LD \`<script>\` tags in \`_app.jsx\` from a \`pageStructuredData\` array passed via \`getStaticProps\`, so any page can declare schema.org types alongside its existing meta.
- Add an \`Organization\` schema to the homepage with logo, description, and \`sameAs\` links to Instagram, the blog, and GitHub.
- Add a \`LodgingBusiness\` schema to Sage and Cactus pages (name, description, url, address, priceRange, numberOfRooms; Sage also includes the hero image).

## Test plan
- [ ] After deploy, run https://search.google.com/test/rich-results on the homepage, /houses/sage, and /houses/cactus to verify each page's schema parses cleanly.
- [ ] Spot-check page source to confirm the \`<script type="application/ld+json">\` tags are present in the head.