### PR TITLE
docs(gsc): add Search Console report for 2026-05-07

### DIFF
--- a/gsc/report-05-07-2026.md
+++ b/gsc/report-05-07-2026.md
@@ -1,0 +1,111 @@
+# Google Search Console Report — 2026-05-07
+
+Period: last 12 months (2025-05-06 → 2026-05-05).
+Search type: Web.
+Sitemap: All known pages.
+
+## Headline numbers
+
+- Total clicks: ~354
+- Total impressions: ~27,000
+- Overall CTR: ~1.3%
+- Avg position: ~12
+
+By device:
+
+| Device  | Clicks | Impressions | CTR   | Position |
+|---------|--------|-------------|-------|----------|
+| Desktop | 186    | 18,169      | 1.02% | 13.1     |
+| Mobile  | 165    | 8,440       | 1.95% | 10.5     |
+| Tablet  | 3      | 397         | 0.76% | 9.1      |
+
+Mobile converts nearly 2× better than desktop despite getting under half the impressions.
+
+## Trend: strong growth in 2026
+
+The daily chart shows a clear inflection in late January 2026.
+
+- May 2025 – mid-January 2026: ~30–80 impressions/day, avg position ~20–30, ~0–2 clicks/day.
+- Late January 2026 onward: 100–400 impressions/day, avg position ~7–10, regular days of 3–8 clicks.
+- Best recent week: 2026-05-02 to 2026-05-05 — 20 clicks on 467 impressions (~4.3% CTR).
+
+Avg position has improved from the high-20s a year ago to single-digits now. The site is moving from page 3 territory into page 1.
+
+## Indexing (Chart 2)
+
+Tracked Feb–May 2026.
+
+- Indexed pages: trended down slightly (47 → 41).
+- Not indexed: trended down (71 → 51) — net cleanup, not new exclusions.
+- Impressions per day rose from ~150 to ~100–170 with multiple 200+ days.
+
+Coverage issues (Critical issues report):
+
+| Reason                                       | Pages |
+|----------------------------------------------|-------|
+| Crawled – currently not indexed              | 17    |
+| Blocked by robots.txt                        | 11    |
+| Alternate page with proper canonical tag     | 9     |
+| Discovered – currently not indexed           | 5     |
+| Excluded by 'noindex' tag                    | 3     |
+| Not found (404)                              | 3     |
+| Page with redirect                           | 3     |
+
+The "crawled but not indexed" bucket (17) and "discovered but not indexed" (5) are the most actionable — Google sees the pages but isn't choosing to index them.
+
+## Top pages
+
+| Page                                                  | Clicks | Impr. | CTR   | Pos.  |
+|-------------------------------------------------------|--------|-------|-------|-------|
+| blog: two-months-at-settleliving                      | 92     | 4,496 | 2.05% | 7.5   |
+| zaratan.world/ (home)                                 | 78     | 4,885 | 1.60% | 9.6   |
+| /houses/sage                                          | 66     | 1,609 | 4.10% | 23.4  |
+| /chorewheel                                           | 30     | 1,660 | 1.81% | 21.6  |
+| /about                                                | 17     | 700   | 2.43% | 8.3   |
+| blog: home                                            | 17     | 354   | 4.80% | 7.5   |
+| blog: story-of-chore-wheel                            | 11     | 324   | 3.40% | 16.1  |
+| blog: running-the-co-op                               | 9      | 820   | 1.10% | 17.5  |
+| blog: colivings-political-economy                     | 1      | 4,547 | 0.02% | 6.2   |
+| blog: the-magic-circle                                | 3      | 1,959 | 0.15% | 9.4   |
+
+Notable:
+
+- **colivings-political-economy** has 4,547 impressions at avg position 6.2 but only 1 click (0.02% CTR). Very high-impression page that isn't earning clicks — likely a title/snippet issue worth investigating.
+- **the-magic-circle** also high-impressions, low-CTR (0.15% at pos 9.4).
+- **/houses/sage** and **/chorewheel** are at avg position 21–23. These rank on page 2; small position gains would unlock significant click growth (sage already converts at 4.1% when shown).
+
+## Top queries
+
+| Query                          | Clicks | Impr. | CTR    | Pos.  |
+|--------------------------------|--------|-------|--------|-------|
+| settle living                  | 17     | 1,173 | 1.45%  | 8.4   |
+| settleliving                   | 12     | 568   | 2.11%  | 6.6   |
+| daniel kronovet                | 11     | 310   | 3.55%  | 8.3   |
+| zaratan                        | 9      | 3,752 | 0.24%  | 9.0   |
+| settle living reviews          | 6      | 212   | 2.83%  | 6.6   |
+| settle living nyc              | 5      | 541   | 0.92%  | 8.2   |
+| chore wheel                    | 3      | 785   | 0.38%  | 21.9  |
+| is settle living legit         | 3      | 88    | 3.41%  | 6.2   |
+
+Observations:
+
+- "settle living" / "settleliving" variants drive most traffic — riding the Settle Living blog post.
+- **"zaratan"** brand query: 3,752 impressions, only 9 clicks (0.24%). Avg pos 9 means it's bouncing around bottom-of-page-1. Should rank #1 for own brand — investigate title tag, snippet, and whether competitors (e.g., "Zaratan Studios", Spanish-language "zaratán") outrank.
+- **"chore wheel"** at position 21.9 — ranking on page 2 for a high-impression term (785). Big opportunity if it can move to page 1.
+- Long tail of misspellings ("zaratam", "zaraton", "zarathan", "zeratan", etc.) — typical brand drift, low value.
+- Many high-impression chore-related queries ("chore wheel app" 388, "wheel of chores" 106, "chores wheel" 141, "online chore wheel" 89) where pages rank 40–80. These are page-3+ rankings that produce zero clicks.
+
+## Geography
+
+- US dominates: 289 clicks / 17,909 impressions (~82% of clicks).
+- UK distant second: 18 clicks / 2,053 impressions.
+- Canada, Germany, Spain, France: small but present.
+- Long tail of 100+ countries with single-digit clicks or zero.
+
+## Top opportunities
+
+1. **Fix CTR on `colivings-political-economy`** — 4.5k impressions at pos 6 producing 1 click is a snippet problem, not a ranking problem.
+2. **Defend the "zaratan" brand query** — 3.7k impressions at 0.24% CTR is leaking branded traffic.
+3. **Push `/chorewheel` and `/houses/sage` from page 2 to page 1** — both already convert well when shown (1.8% and 4.1%). Internal linking, on-page SEO, or backlinks could move position 21 → 10.
+4. **Resolve indexing gaps** — 17 "crawled, not indexed" and 5 "discovered, not indexed" pages. Audit which URLs and whether they should be indexed.
+5. **Capitalize on the 2026 momentum** — impressions are 3–5× last year's baseline and average position is now single-digits. Post-frequency or topical-cluster expansion around chore wheel / coliving keywords would compound.


### PR DESCRIPTION
Adds a Google Search Console summary report to `gsc/report-05-07-2026.md` covering the last 12 months. Highlights a clear traffic inflection in late January 2026 (impressions 3–5× baseline, avg position improved from ~25 to ~7–10), top pages and queries, and CTR leaks on high-impression pages like `colivings-political-economy` and the brand query "zaratan". Also flags page-2 ranking opportunities for `/houses/sage` and `/chorewheel`, and indexing gaps to investigate.