### PR TITLE
chore(pricing): retune NELA query to house pin, radius 4

### DIFF
--- a/analytics/pricing/report-2026-05-16.md
+++ b/analytics/pricing/report-2026-05-16.md
@@ -6,13 +6,23 @@ Prices filtered to $500–$5,000. Posts matching "wanted/seeking/looking for" ex
 
 ## NELA
 
-**Query:** `https://losangeles.craigslist.org/search/los-angeles-ca/roo?lat=34.11&lon=-118.21&search_distance=2`
-**Listings parsed:** 15
+**Query:** `https://losangeles.craigslist.org/search/los-angeles-ca/roo?lat=34.11&lon=-118.19&search_distance=4`
+**Listings parsed:** 56
 
 | neighborhood | n | p25 | median | p75 |
 |---|---|---|---|---|
+| alhambra | 11 | $825 | $1,100 | $1,100 |
 | highland park | 8 | $1,206 | $1,330 | $1,425 |
-| central la 213/323 | 2 | $1,121 | $1,243 | $1,364 |
+| glendale | 6 | $1,050 | $1,225 | $1,438 |
+| los angeles | 5 | $800 | $1,100 | $1,300 |
+| central la 213/323 | 3 | $1,050 | $1,100 | $1,293 |
+| pasadena | 3 | $1,300 | $1,400 | $1,600 |
+| south pasadena | 3 | $1,313 | $1,325 | $1,403 |
 | glassell park | 2 | $781 | $886 | $992 |
+| san gabriel valley | 2 | $838 | $875 | $913 |
+| alhambra, south pasadena | 2 | $1,299 | $1,299 | $1,299 |
+| lincoln heights | 1 | $880 | $880 | $880 |
+| alhambra/elac/csula/usc med. campus | 1 | $700 | $700 | $700 |
 | eagle rock | 1 | $1,450 | $1,450 | $1,450 |
-| san gabriel valley | 1 | $950 | $950 | $950 |
+| university hills | 1 | $825 | $825 | $825 |
+| los angeles/boyle heights | 1 | $950 | $950 | $950 |


### PR DESCRIPTION
## Summary
- Moved the search pin to the coliving house location (34.11, -118.19, previously the HLP centroid at -118.21).
- Widened radius from 2 → 4 miles.
- Highland Park signal unchanged (n=8, median \$1,330); the wider, house-anchored circle adds real signal on Alhambra (n=11), Glendale (n=6), Pasadena (n=3), and South Pasadena (n=3).

## Test plan
- [x] Ran \`node strategy/housing-agent.mjs\` locally; 56 listings parsed, HLP stats stable.