### PR TITLE
feat(gsc): add Search Console agent

### DIFF
--- a/.github/workflows/gsc-agent.yml
+++ b/.github/workflows/gsc-agent.yml
@@ -1,0 +1,63 @@
+name: GSC Agent
+
+on:
+  schedule:
+    - cron: '0 0 1 * *'
+  workflow_dispatch:
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Pull GSC data
+        env:
+          GSC_CLIENT_ID: ${{ secrets.GSC_CLIENT_ID }}
+          GSC_CLIENT_SECRET: ${{ secrets.GSC_CLIENT_SECRET }}
+          GSC_REFRESH_TOKEN: ${{ secrets.GSC_REFRESH_TOKEN }}
+        run: node scripts/gsc-agent/run.mjs > /tmp/gsc-data.md
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ github.token }}
+          prompt: |
+            REPO: ${{ github.repository }}
+            RUN ID: ${{ github.run_id }}
+
+            You are the Zaratan GSC agent. The repo is checked out at the workspace root.
+
+            Inputs:
+            - GSC data for the last 28 days is at `/tmp/gsc-data.md` (raw tables: totals, top queries, top pages, country, device, daily).
+            - Prior GSC reports live in `analytics/gsc/` named `report-MM-DD-YYYY.md`. Read the most recent one to anchor trends.
+            - Product context lives in `spec/GROWTH.md`, `spec/HOUSING.md`, `spec/TOOLS.md`.
+
+            Task:
+            1. Read the inputs above.
+            2. Create a new file `analytics/gsc/report-<MM-DD-YYYY>.md` (use today's UTC date) containing:
+               - The raw data tables from `/tmp/gsc-data.md`
+               - Headline numbers (3-4 bullets): clicks, impressions, CTR, avg position, plus direction vs the prior report
+               - What is working (queries / pages gaining ground)
+               - What is underperforming (high-impression / low-CTR queries; pages slipping in position)
+               - 3-5 specific, prioritized SEO recommendations. For each: target query or page, change, expected impact, effort (S/M/L)
+               Be concrete. Reference exact queries and page paths. No fluff.
+            3. Create a new branch `gsc-agent/report-${{ github.run_id }}`, commit only the new report file with message `chore(gsc): monthly report`, push to origin, and open a PR to `main` titled `chore(gsc): monthly report` with a 1-2 sentence body summarizing the top recommendation.
+          claude_args: |
+            --max-turns 30
+            --allowedTools "Read,Write,Edit,Bash"

--- a/analytics/gsc/report-06-03-2026.md
+++ b/analytics/gsc/report-06-03-2026.md
@@ -1,0 +1,86 @@
+# Google Search Console Report — 2026-06-03
+
+Period: last 28 days (2026-05-06 → 2026-06-03).
+Search type: Web.
+Site: `sc-domain:zaratan.world`.
+
+First report from the automated GSC agent (OAuth data pull).
+Note: the prior report (05-07) covered a 12-month window, so absolute click/impression totals are not directly comparable.
+Avg position (9.2) is consistent with the single-digit position that window ended at.
+
+## Headline numbers
+
+- Clicks: 80
+- Impressions: 3,353
+- CTR: 2.39%
+- Avg position: 9.2
+
+By device:
+
+| Device  | Clicks | Impressions | CTR   | Position |
+|---------|-------:|------------:|------:|---------:|
+| Mobile  | 50     | 1,231       | 4.06% | 7.0      |
+| Desktop | 30     | 2,108       | 1.42% | 10.5     |
+| Tablet  | 0      | 14          | 0.00% | 6.4      |
+
+Mobile converts ~3× better than desktop (4.06% vs 1.42%) and ranks higher (pos 7.0 vs 10.5), despite getting ~half the impressions.
+Same pattern as the 05-07 report, now wider.
+
+## Top pages
+
+| Page                                          | Clicks | Impr. | CTR    | Pos.  |
+|-----------------------------------------------|-------:|------:|-------:|------:|
+| blog: two-months-at-settleliving              | 42     | 1,439 | 2.92%  | 6.2   |
+| zaratan.world/ (home)                         | 13     | 616   | 2.11%  | 6.9   |
+| /houses/sage                                  | 13     | 261   | 4.98%  | 12.1  |
+| /about                                        | 4      | 95    | 4.21%  | 4.8   |
+| www: /houses/sage                             | 3      | 25    | 12.00% | 3.6   |
+| www: /about                                   | 2      | 18    | 11.11% | 5.1   |
+| blog: story-of-chore-wheel                    | 1      | 45    | 2.22%  | 13.5  |
+| blog: quadratic-v-pairwise                    | 0      | 136   | 0.00%  | 10.6  |
+| blog: playing-with-reality                    | 0      | 189   | 0.00%  | 19.1  |
+
+Notable:
+
+- **www vs non-www split.** `/houses/sage` and `/about` each appear twice — once on `zaratan.world` and once on `www.zaratan.world`.
+  The www versions rank *higher* (pos 3.6 / 5.1) but get a fraction of the impressions, while the apex versions carry the volume at worse positions (12.1 / 4.8).
+  Ranking signals and clicks are being split across two hostnames. Canonicalize to one.
+- **/houses/sage** converts at 4.98% but sits at avg position 12.1 — page 2. The www variant at pos 3.6 shows the page *can* rank; the apex version just needs to catch up.
+- **blog: playing-with-reality** (189 impr, pos 19.1) and **quadratic-v-pairwise** (136 impr, pos 10.6) draw impressions but zero clicks — page-2 rankings on niche terms.
+
+## Top queries
+
+| Query                     | Clicks | Impr. | CTR    | Pos.  |
+|---------------------------|-------:|------:|-------:|------:|
+| settle living             | 5      | 308   | 1.62%  | 6.2   |
+| settleliving              | 3      | 107   | 2.80%  | 6.0   |
+| is settle living legit    | 2      | 36    | 5.56%  | 3.4   |
+| settled living nyc        | 2      | 24    | 8.33%  | 6.0   |
+| settle living nyc         | 1      | 198   | 0.51%  | 5.6   |
+| settle living reviews     | 1      | 34    | 2.94%  | 4.4   |
+| sage house                | 1      | 52    | 1.92%  | 9.7   |
+| chore wheel meaning       | 0      | 16    | 0.00%  | 10.8  |
+| sagehouse                 | 0      | 18    | 0.00%  | 9.5   |
+| saige house               | 0      | 10    | 0.00%  | 8.1   |
+| chore                     | 0      | 10    | 0.00%  | 52.9  |
+
+Observations:
+
+- "settle living" variants still drive the bulk of traffic, riding the two-months-at-settleliving blog post.
+- **"settle living nyc"**: 198 impressions at position 5.6, but only 1 click (0.51% CTR). Highest-impression query on the list and the clearest snippet/title problem — ranks on page 1 but isn't earning the click.
+- **Chore wheel cluster** ("chore wheel meaning" pos 10.8, "chorewheel" pos 6.3, "chore wheel" pos 7.4) draws impressions at page-1 positions but zero clicks this period. The `/chorewheel` page only pulled 1 click / 34 impr.
+- **"sage house" / "sagehouse" / "saige house"** all draw impressions at pos 8–10 with near-zero clicks — these feed `/houses/sage`, reinforcing the canonicalization + position push above.
+
+## Geography
+
+- US dominates: 72 clicks / 2,524 impressions (~90% of clicks).
+- UK, Canada distant followers (3 and 2 clicks).
+- Long tail of 100+ countries with single-digit or zero clicks.
+
+## Top opportunities
+
+1. **Fix the www vs non-www split.** `/houses/sage` and `/about` rank on both hostnames, dividing impressions and link signal. Pick a canonical host (redirect www → apex or set rel=canonical) so one version accumulates all the authority.
+2. **Fix CTR on "settle living nyc"** — 198 impressions at position 5.6 producing 1 click is a title/snippet problem, not a ranking problem.
+3. **Push `/houses/sage` from page 2 to page 1.** It already converts at ~5% and the www variant proves it can rank top-5. On-page SEO and internal linking should close the gap.
+4. **Recover the chore wheel cluster.** Multiple queries rank page-1 (pos 6–11) but earn zero clicks, and `/chorewheel` traffic has thinned. Audit titles/snippets and internal links to the page.
+5. **Keep feeding the Settle Living momentum.** The two-months-at-settleliving post is the single biggest click driver; related "is X legit / reviews / nyc" queries convert well. More content in that vein would compound.

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   },
   "devDependencies": {
     "@google-analytics/data": "^5.2.2",
-    "cheerio": "^1.0.0"
+    "cheerio": "^1.0.0",
+    "googleapis": "^144.0.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,6 +42,9 @@ importers:
       cheerio:
         specifier: ^1.0.0
         version: 1.2.0
+      googleapis:
+        specifier: ^144.0.0
+        version: 144.0.0
 
 packages:
 
@@ -856,6 +859,14 @@ packages:
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
 
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
+    engines: {node: '>= 0.4'}
+
   caniuse-lite@1.0.30001791:
     resolution: {integrity: sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==}
 
@@ -960,6 +971,10 @@ packages:
     resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
     engines: {node: '>=12'}
 
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
   duplexify@4.1.3:
     resolution: {integrity: sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==}
 
@@ -992,6 +1007,18 @@ packages:
   entities@7.0.1:
     resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
     engines: {node: '>=0.12'}
+
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
+  es-object-atoms@1.1.2:
+    resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
+    engines: {node: '>= 0.4'}
 
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
@@ -1032,9 +1059,20 @@ packages:
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
 
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  gaxios@6.7.1:
+    resolution: {integrity: sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==}
+    engines: {node: '>=14'}
+
   gaxios@7.1.4:
     resolution: {integrity: sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==}
     engines: {node: '>=18'}
+
+  gcp-metadata@6.1.1:
+    resolution: {integrity: sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==}
+    engines: {node: '>=14'}
 
   gcp-metadata@8.1.2:
     resolution: {integrity: sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==}
@@ -1043,6 +1081,14 @@ packages:
   get-caller-file@2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
+
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
 
   github-from-package@0.0.0:
     resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
@@ -1056,13 +1102,45 @@ packages:
     resolution: {integrity: sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==}
     engines: {node: '>=18'}
 
+  google-auth-library@9.15.1:
+    resolution: {integrity: sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==}
+    engines: {node: '>=14'}
+
   google-gax@5.0.6:
     resolution: {integrity: sha512-1kGbqVQBZPAAu4+/R1XxPQKP0ydbNYoLAr4l0ZO2bMV0kLyLW4I1gAk++qBLWt7DPORTzmWRMsCZe86gDjShJA==}
     engines: {node: '>=18'}
 
+  google-logging-utils@0.0.2:
+    resolution: {integrity: sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==}
+    engines: {node: '>=14'}
+
   google-logging-utils@1.1.3:
     resolution: {integrity: sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==}
     engines: {node: '>=14'}
+
+  googleapis-common@7.2.0:
+    resolution: {integrity: sha512-/fhDZEJZvOV3X5jmD+fKxMqma5q2Q9nZNSF3kn1F18tpxmA86BcTxAGBQdM0N89Z3bEaIs+HVznSmFJEAmMTjA==}
+    engines: {node: '>=14.0.0'}
+
+  googleapis@144.0.0:
+    resolution: {integrity: sha512-ELcWOXtJxjPX4vsKMh+7V+jZvgPwYMlEhQFiu2sa9Qmt5veX8nwXPksOWGGN6Zk4xCiLygUyaz7xGtcMO+Onxw==}
+    engines: {node: '>=14.0.0'}
+
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
+  gtoken@7.1.0:
+    resolution: {integrity: sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==}
+    engines: {node: '>=14.0.0'}
+
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.3:
+    resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
+    engines: {node: '>= 0.4'}
 
   htmlparser2@10.1.0:
     resolution: {integrity: sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==}
@@ -1098,6 +1176,10 @@ packages:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
 
+  is-stream@2.0.1:
+    resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
+    engines: {node: '>=8'}
+
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
@@ -1128,6 +1210,10 @@ packages:
 
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
 
   mimic-response@3.1.0:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
@@ -1191,6 +1277,15 @@ packages:
     engines: {node: '>=10.5.0'}
     deprecated: Use your platform's native DOMException instead
 
+  node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+
   node-fetch@3.3.2:
     resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -1205,6 +1300,10 @@ packages:
   object-hash@3.0.0:
     resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
     engines: {node: '>= 6'}
+
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
 
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
@@ -1264,6 +1363,10 @@ packages:
 
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
+
+  qs@6.15.2:
+    resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
+    engines: {node: '>=0.6'}
 
   rc@1.2.8:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
@@ -1357,6 +1460,22 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
+  side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.0:
+    resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
+    engines: {node: '>= 0.4'}
+
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
@@ -1448,6 +1567,9 @@ packages:
   text-decoder@1.2.7:
     resolution: {integrity: sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==}
 
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -1471,6 +1593,9 @@ packages:
     resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
     engines: {node: '>=20.18.1'}
 
+  url-template@2.0.8:
+    resolution: {integrity: sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==}
+
   use-sync-external-store@1.6.0:
     resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
     peerDependencies:
@@ -1479,12 +1604,20 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
+  uuid@9.0.1:
+    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
+    hasBin: true
+
   warning@4.0.3:
     resolution: {integrity: sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==}
 
   web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
+
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
 
   whatwg-encoding@3.1.1:
     resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
@@ -1494,6 +1627,9 @@ packages:
   whatwg-mimetype@4.0.0:
     resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
     engines: {node: '>=18'}
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
@@ -2646,6 +2782,16 @@ snapshots:
       base64-js: 1.5.1
       ieee754: 1.2.1
 
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
+
   caniuse-lite@1.0.30001791: {}
 
   cheerio-select@2.1.0:
@@ -2760,6 +2906,12 @@ snapshots:
 
   dotenv@16.6.1: {}
 
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
   duplexify@4.1.3:
     dependencies:
       end-of-stream: 1.4.5
@@ -2791,6 +2943,14 @@ snapshots:
   entities@6.0.1: {}
 
   entities@7.0.1: {}
+
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
+  es-object-atoms@1.1.2:
+    dependencies:
+      es-errors: 1.3.0
 
   escalade@3.2.0: {}
 
@@ -2833,12 +2993,34 @@ snapshots:
 
   fs-constants@1.0.0: {}
 
+  function-bind@1.1.2: {}
+
+  gaxios@6.7.1:
+    dependencies:
+      extend: 3.0.2
+      https-proxy-agent: 7.0.6
+      is-stream: 2.0.1
+      node-fetch: 2.7.0
+      uuid: 9.0.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
   gaxios@7.1.4:
     dependencies:
       extend: 3.0.2
       https-proxy-agent: 7.0.6
       node-fetch: 3.3.2
     transitivePeerDependencies:
+      - supports-color
+
+  gcp-metadata@6.1.1:
+    dependencies:
+      gaxios: 6.7.1
+      google-logging-utils: 0.0.2
+      json-bigint: 1.0.0
+    transitivePeerDependencies:
+      - encoding
       - supports-color
 
   gcp-metadata@8.1.2:
@@ -2850,6 +3032,24 @@ snapshots:
       - supports-color
 
   get-caller-file@2.0.5: {}
+
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.2
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.3
+      math-intrinsics: 1.1.0
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.2
 
   github-from-package@0.0.0: {}
 
@@ -2873,6 +3073,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  google-auth-library@9.15.1:
+    dependencies:
+      base64-js: 1.5.1
+      ecdsa-sig-formatter: 1.0.11
+      gaxios: 6.7.1
+      gcp-metadata: 6.1.1
+      gtoken: 7.1.0
+      jws: 4.0.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
   google-gax@5.0.6:
     dependencies:
       '@grpc/grpc-js': 1.14.3
@@ -2889,7 +3101,45 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  google-logging-utils@0.0.2: {}
+
   google-logging-utils@1.1.3: {}
+
+  googleapis-common@7.2.0:
+    dependencies:
+      extend: 3.0.2
+      gaxios: 6.7.1
+      google-auth-library: 9.15.1
+      qs: 6.15.2
+      url-template: 2.0.8
+      uuid: 9.0.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  googleapis@144.0.0:
+    dependencies:
+      google-auth-library: 9.15.1
+      googleapis-common: 7.2.0
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  gopd@1.2.0: {}
+
+  gtoken@7.1.0:
+    dependencies:
+      gaxios: 6.7.1
+      jws: 4.0.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  has-symbols@1.1.0: {}
+
+  hasown@2.0.3:
+    dependencies:
+      function-bind: 1.1.2
 
   htmlparser2@10.1.0:
     dependencies:
@@ -2930,6 +3180,8 @@ snapshots:
 
   is-fullwidth-code-point@3.0.0: {}
 
+  is-stream@2.0.1: {}
+
   isexe@2.0.0: {}
 
   jackspeak@3.4.3:
@@ -2964,6 +3216,8 @@ snapshots:
       js-tokens: 4.0.0
 
   lru-cache@10.4.3: {}
+
+  math-intrinsics@1.1.0: {}
 
   mimic-response@3.1.0: {}
 
@@ -3014,6 +3268,10 @@ snapshots:
 
   node-domexception@1.0.0: {}
 
+  node-fetch@2.7.0:
+    dependencies:
+      whatwg-url: 5.0.0
+
   node-fetch@3.3.2:
     dependencies:
       data-uri-to-buffer: 4.0.1
@@ -3027,6 +3285,8 @@ snapshots:
   object-assign@4.1.1: {}
 
   object-hash@3.0.0: {}
+
+  object-inspect@1.13.4: {}
 
   once@1.4.0:
     dependencies:
@@ -3114,6 +3374,10 @@ snapshots:
     dependencies:
       end-of-stream: 1.4.5
       once: 1.4.0
+
+  qs@6.15.2:
+    dependencies:
+      side-channel: 1.1.0
 
   rc@1.2.8:
     dependencies:
@@ -3271,6 +3535,34 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
+  side-channel-list@1.0.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+
+  side-channel@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.1
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
+
   signal-exit@4.1.0: {}
 
   simple-concat@1.0.1: {}
@@ -3397,6 +3689,8 @@ snapshots:
     transitivePeerDependencies:
       - react-native-b4a
 
+  tr46@0.0.3: {}
+
   tslib@2.8.1: {}
 
   tunnel-agent@0.6.0:
@@ -3419,11 +3713,15 @@ snapshots:
 
   undici@7.25.0: {}
 
+  url-template@2.0.8: {}
+
   use-sync-external-store@1.6.0(react@18.3.1):
     dependencies:
       react: 18.3.1
 
   util-deprecate@1.0.2: {}
+
+  uuid@9.0.1: {}
 
   warning@4.0.3:
     dependencies:
@@ -3431,11 +3729,18 @@ snapshots:
 
   web-streams-polyfill@3.3.3: {}
 
+  webidl-conversions@3.0.1: {}
+
   whatwg-encoding@3.1.1:
     dependencies:
       iconv-lite: 0.6.3
 
   whatwg-mimetype@4.0.0: {}
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
 
   which@2.0.2:
     dependencies:

--- a/scripts/gsc-agent/get-refresh-token.mjs
+++ b/scripts/gsc-agent/get-refresh-token.mjs
@@ -1,0 +1,63 @@
+// One-time OAuth flow to mint a refresh token for the GSC agent.
+//
+// Usage:
+//   GSC_CLIENT_ID=... GSC_CLIENT_SECRET=... node scripts/gsc-agent/get-refresh-token.mjs
+//
+// Opens a local server on :53682, prints an auth URL to paste into a browser,
+// captures the redirect, and prints the refresh token to stdout. Store the
+// printed token as the GSC_REFRESH_TOKEN GitHub secret.
+
+import http from 'node:http';
+import { URL } from 'node:url';
+import { google } from 'googleapis';
+
+const CLIENT_ID = process.env.GSC_CLIENT_ID;
+const CLIENT_SECRET = process.env.GSC_CLIENT_SECRET;
+const PORT = 53682;
+const REDIRECT = `http://localhost:${PORT}/oauth2callback`;
+
+if (!CLIENT_ID || !CLIENT_SECRET) {
+  console.error('Missing GSC_CLIENT_ID or GSC_CLIENT_SECRET');
+  process.exit(1);
+}
+
+const oauth2 = new google.auth.OAuth2(CLIENT_ID, CLIENT_SECRET, REDIRECT);
+
+const authUrl = oauth2.generateAuthUrl({
+  access_type: 'offline',
+  prompt: 'consent',
+  scope: ['https://www.googleapis.com/auth/webmasters.readonly'],
+});
+
+const server = http.createServer(async (req, res) => {
+  try {
+    const code = new URL(req.url, REDIRECT).searchParams.get('code');
+    if (!code) {
+      res.statusCode = 400;
+      res.end('No code in callback');
+      return;
+    }
+    const { tokens } = await oauth2.getToken(code);
+    res.end('Done. You can close this tab.');
+    if (!tokens.refresh_token) {
+      console.error('\nNo refresh_token returned. Revoke the app at https://myaccount.google.com/permissions and re-run.');
+      process.exit(1);
+    }
+    console.log('\nREFRESH TOKEN:\n');
+    console.log(tokens.refresh_token);
+    console.log('\nStore this as the GSC_REFRESH_TOKEN GitHub secret.');
+    server.close();
+  } catch (err) {
+    console.error(err);
+    res.statusCode = 500;
+    res.end('Error — check terminal');
+    server.close();
+    process.exit(1);
+  }
+});
+
+server.listen(PORT, () => {
+  console.log(`Listening on http://localhost:${PORT}`);
+  console.log('\nOpen this URL in a browser:\n');
+  console.log(authUrl);
+});

--- a/scripts/gsc-agent/run.mjs
+++ b/scripts/gsc-agent/run.mjs
@@ -1,0 +1,96 @@
+import { google } from 'googleapis';
+
+const SITE = process.env.GSC_SITE_URL ?? 'sc-domain:zaratan.world';
+const DAYS = Number(process.env.GSC_DAYS ?? 28);
+
+const oauth2 = new google.auth.OAuth2(
+  process.env.GSC_CLIENT_ID,
+  process.env.GSC_CLIENT_SECRET,
+);
+oauth2.setCredentials({ refresh_token: process.env.GSC_REFRESH_TOKEN });
+
+const webmasters = google.webmasters({ version: 'v3', auth: oauth2 });
+
+const iso = (d) => d.toISOString().slice(0, 10);
+const endDate = iso(new Date(Date.now() - 86400000));
+const startDate = iso(new Date(Date.now() - (DAYS + 1) * 86400000));
+
+const query = (dimensions, rowLimit = 50) => webmasters.searchanalytics.query({
+  siteUrl: SITE,
+  requestBody: { startDate, endDate, dimensions, rowLimit },
+}).then((r) => r.data.rows ?? []);
+
+const [totals, queries, pages, countries, devices, dates] = await Promise.all([
+  query([], 1),
+  query(['query'], 50),
+  query(['page'], 50),
+  query(['country'], 20),
+  query(['device']),
+  query(['date'], DAYS + 1),
+]);
+
+const pct = (n) => `${(n * 100).toFixed(2)}%`;
+const fix = (n, d = 1) => n.toFixed(d);
+
+const row = (cells) => `| ${cells.join(' | ')} |`;
+const table = (headers, aligns, rows) => [
+  row(headers),
+  row(aligns),
+  ...rows.map(row),
+].join('\n');
+
+console.log(`# GSC raw data\n`);
+console.log(`Site: \`${SITE}\``);
+console.log(`Period: ${startDate} → ${endDate} (${DAYS} days)\n`);
+
+if (totals[0]) {
+  const t = totals[0];
+  console.log(`## Totals\n`);
+  console.log(`- Clicks: ${t.clicks}`);
+  console.log(`- Impressions: ${t.impressions}`);
+  console.log(`- CTR: ${pct(t.ctr)}`);
+  console.log(`- Avg position: ${fix(t.position)}\n`);
+}
+
+const metricRows = (rows) => rows.map((r) => [
+  r.keys[0],
+  r.clicks,
+  r.impressions,
+  pct(r.ctr),
+  fix(r.position),
+]);
+
+console.log(`## Top queries\n`);
+console.log(table(
+  ['Query', 'Clicks', 'Impressions', 'CTR', 'Position'],
+  ['---', '---:', '---:', '---:', '---:'],
+  metricRows(queries),
+));
+
+console.log(`\n## Top pages\n`);
+console.log(table(
+  ['Page', 'Clicks', 'Impressions', 'CTR', 'Position'],
+  ['---', '---:', '---:', '---:', '---:'],
+  metricRows(pages),
+));
+
+console.log(`\n## By country\n`);
+console.log(table(
+  ['Country', 'Clicks', 'Impressions', 'CTR', 'Position'],
+  ['---', '---:', '---:', '---:', '---:'],
+  metricRows(countries),
+));
+
+console.log(`\n## By device\n`);
+console.log(table(
+  ['Device', 'Clicks', 'Impressions', 'CTR', 'Position'],
+  ['---', '---:', '---:', '---:', '---:'],
+  metricRows(devices),
+));
+
+console.log(`\n## Daily\n`);
+console.log(table(
+  ['Date', 'Clicks', 'Impressions', 'CTR', 'Position'],
+  ['---', '---:', '---:', '---:', '---:'],
+  metricRows(dates),
+));


### PR DESCRIPTION
Adds a monthly GSC agent mirroring the CRO agent.

## What
- `.github/workflows/gsc-agent.yml` — monthly cron + manual dispatch; pulls Search Console data, then Claude writes a report and opens a PR.
- `scripts/gsc-agent/run.mjs` — pulls 28-day GSC data (totals, queries, pages, country, device, daily) via OAuth refresh token, emits markdown tables.
- `scripts/gsc-agent/get-refresh-token.mjs` — one-time local helper for the OAuth dance.
- `googleapis` devDep.

## Auth
Uses OAuth (own Google account + refresh token) instead of a service account, since GSC rejected the service account email ("email not found") on both Domain and URL-prefix properties. Secrets: `GSC_CLIENT_ID`, `GSC_CLIENT_SECRET`, `GSC_REFRESH_TOKEN`.

Verified locally — data pull works. First report lands in a follow-up commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)